### PR TITLE
Refactor permissions plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Auth Permissions
+
+This package provides an RBAC permissions guard for NestJS. It is intended to be used together with the JWT plugin from `@open-auth-kit`.
+
+## Installation
+
+```bash
+pnpm add @open-auth-kit/auth-permissions
+```
+
+## Usage
+
+1. Register `PermissionsModule` and supply a provider for `PERMISSIONS_PROVIDER`.
+2. Use the `@Permissions()` decorator on endpoints to specify required permissions.
+3. Apply `PermissionsGuard` in controllers or globally.
+
+```ts
+import {
+  Permissions,
+  PermissionsModule,
+  PermissionsGuard,
+  PERMISSIONS_PROVIDER,
+  PermissionsProvider,
+} from '@open-auth-kit/auth-permissions';
+
+@Module({
+  imports: [
+    PermissionsModule.register({
+      provide: PERMISSIONS_PROVIDER,
+      useClass: MyPermissionsService,
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+Implement `PermissionsProvider` in `MyPermissionsService` to fetch permissions for your users.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@open-auth-kit/auth-permissions",
+  "version": "0.0.1",
+  "description": "NestJS RBAC permissions plugin",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "type": "commonjs",
+  "files": [
+    "dist/**/*"
+  ],
+  "peerDependencies": {
+    "@nestjs/common": "^11.1.0",
+    "@nestjs/core": "^11.1.0"
+  },
+  "scripts": {
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "docs": "typedoc",
+    "lint": "eslint \"src/**/*.ts\" --report-unused-disable-directives",
+    "test": "jest --coverage",
+    "test:watch": "jest --watch",
+    "prepare": "npm run build"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-auth-kit/auth-permissions.git"
+  },
+  "keywords": [
+    "nestjs",
+    "auth",
+    "jwt",
+    "permissions",
+    "rbac"
+  ],
+  "author": "Kim Valentin",
+  "bugs": {
+    "url": "https://github.com/open-auth-kit/auth-permissions/issues"
+  },
+  "homepage": "https://github.com/open-auth-kit/auth-permissions#readme",
+  "devDependencies": {
+    "@eslint/js": "^9.25.1",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.15.3",
+    "@typescript-eslint/eslint-plugin": "^8.31.0",
+    "@typescript-eslint/parser": "^8.31.0",
+    "eslint": "^9.25.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.2",
+    "typedoc": "^0.28.3",
+    "typedoc-plugin-markdown": "^4.6.3",
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.31.0"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "pnpm@8.6.3",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/src/decorators/permissions.decorator.ts
+++ b/src/decorators/permissions.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const PERMISSIONS_KEY = 'permissions';
+export type Permission = string;
+
+export const Permissions = (...permissions: Permission[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);

--- a/src/guards/permissions.guard.ts
+++ b/src/guards/permissions.guard.ts
@@ -1,0 +1,34 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { PERMISSIONS_KEY, Permission } from '../decorators/permissions.decorator';
+import {
+  PERMISSIONS_PROVIDER,
+  PermissionsProvider,
+} from '../interfaces/permissions-provider.interface';
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    @Inject(PERMISSIONS_PROVIDER) private readonly permissionsService: PermissionsProvider,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const required = this.reflector.get<Permission[]>(PERMISSIONS_KEY, context.getHandler()) || [];
+    if (!required.length) {
+      return true;
+    }
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    if (!user) {
+      return false;
+    }
+    const userPermissions = await this.permissionsService.getPermissions(user.id);
+    return required.every((perm) => userPermissions.includes(perm));
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+export * from './decorators/permissions.decorator';
+export * from './guards/permissions.guard';
+export * from './permissions.module';
+export * from './interfaces/permissions-provider.interface';

--- a/src/interfaces/permissions-provider.interface.ts
+++ b/src/interfaces/permissions-provider.interface.ts
@@ -1,0 +1,5 @@
+export interface PermissionsProvider {
+  getPermissions(userId: string): Promise<string[]>;
+}
+
+export const PERMISSIONS_PROVIDER = 'PERMISSIONS_PROVIDER';

--- a/src/permissions.module.ts
+++ b/src/permissions.module.ts
@@ -1,0 +1,15 @@
+import { DynamicModule, Global, Module, Provider } from '@nestjs/common';
+import { PermissionsGuard } from './guards/permissions.guard';
+import { PermissionsProvider } from './interfaces/permissions-provider.interface';
+
+@Global()
+@Module({})
+export class PermissionsModule {
+  static register(service: Provider<PermissionsProvider>): DynamicModule {
+    return {
+      module: PermissionsModule,
+      providers: [service, PermissionsGuard],
+      exports: [PermissionsGuard, service],
+    };
+  }
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist/cjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "dist/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "sourceMap": true,
+    "strict": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- rework package json to match core plugin organization
- remove built-in service and introduce provider interface
- update guard and module to use injection token
- translate README to English
- add separate tsconfig files for cjs and esm builds

## Testing
- `pnpm install --frozen-lockfile` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.6.3.tgz)*
- `npm run build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.6.3.tgz)*